### PR TITLE
Ingest livestock data COL-979 COL-980 COL-981

### DIFF
--- a/colombia/data/models.py
+++ b/colombia/data/models.py
@@ -7,8 +7,8 @@ from atlas_core.model_mixins import IDMixin
 from ..core import db
 
 from ..metadata.models import (Location, HSProduct, Industry, Occupation,
-                               Country, product_enum, industry_enum,
-                               occupation_enum)
+                               Country, Livestock, product_enum, industry_enum,
+                               occupation_enum, livestock_enum)
 
 
 class XProductYear(BaseModel, IDMixin):
@@ -323,3 +323,18 @@ class OccupationIndustryYear(BaseModel, IDMixin):
 
     average_wages = db.Column(db.Integer)
     num_vacancies = db.Column(db.Integer)
+
+
+class CountryLivestockYear(BaseModel, IDMixin):
+
+    __tablename__ = "country_livestock_year"
+
+    location_id = db.Column(db.Integer, db.ForeignKey(Location.id))
+    livestock_id = db.Column(db.Integer, db.ForeignKey(Livestock.id))
+    livestock_level = db.Column(livestock_enum)
+
+    location = db.relationship(Location)
+    livestock = db.relationship(Livestock)
+
+    num_livestock = db.Column(db.Integer)
+    num_farms = db.Column(db.Integer)

--- a/colombia/data/models.py
+++ b/colombia/data/models.py
@@ -325,16 +325,29 @@ class OccupationIndustryYear(BaseModel, IDMixin):
     num_vacancies = db.Column(db.Integer)
 
 
-class CountryLivestockYear(BaseModel, IDMixin):
+class XLivestockYear(BaseModel, IDMixin):
 
-    __tablename__ = "country_livestock_year"
+    __abstract__ = True
 
-    location_id = db.Column(db.Integer, db.ForeignKey(Location.id))
-    livestock_id = db.Column(db.Integer, db.ForeignKey(Livestock.id))
+    @declared_attr
+    def location_id(cls):
+        return db.Column(db.Integer, db.ForeignKey(Location.id))
+
+    @declared_attr
+    def livestock_id(cls):
+        return db.Column(db.Integer, db.ForeignKey(Livestock.id))
+
     livestock_level = db.Column(livestock_enum)
-
-    location = db.relationship(Location)
-    livestock = db.relationship(Livestock)
 
     num_livestock = db.Column(db.Integer)
     num_farms = db.Column(db.Integer)
+
+
+class CountryLivestockYear(XLivestockYear):
+    __tablename__ = "country_livestock_year"
+
+class DepartmentLivestockYear(XLivestockYear):
+    __tablename__ = "department_livestock_year"
+
+class MunicipalityLivestockYear(XLivestockYear):
+    __tablename__ = "municipality_livestock_year"

--- a/colombia/datasets.py
+++ b/colombia/datasets.py
@@ -1086,9 +1086,9 @@ livestock_template = {
     "digit_padding": {
         "location": None,
     },
-    "facet_fields": ["livestock", "location"],
+    "facet_fields": ["location", "livestock"],
     "facets": {
-        ("livestock_id", "location_id"): {
+        ("location_id", "livestock_id"): {
             "num_livestock": first,
             "num_farms": first,
         }

--- a/colombia/import.py
+++ b/colombia/import.py
@@ -242,21 +242,21 @@ if __name__ == "__main__":
             # Livestock - country
             ret = process_dataset(livestock_level1_country)
             df = ret[('location_id', 'livestock_id')].reset_index()
-            df["location_level"] = "level1"
+            df["livestock_level"] = "level1"
             df.to_sql("country_livestock_year", db.engine, index=False,
                       chunksize=10000, if_exists="append")
 
             # Livestock - department
             ret = process_dataset(livestock_level1_department)
             df = ret[('location_id', 'livestock_id')].reset_index()
-            df["location_level"] = "level1"
+            df["livestock_level"] = "level1"
             df.to_sql("department_livestock_year", db.engine, index=False,
                       chunksize=10000, if_exists="append")
 
             # Livestock - municipality
             ret = process_dataset(livestock_level1_municipality)
             df = ret[('location_id', 'livestock_id')].reset_index()
-            df["location_level"] = "level1"
+            df["livestock_level"] = "level1"
             df.to_sql("municipality_livestock_year", db.engine, index=False,
                       chunksize=10000, if_exists="append")
 

--- a/colombia/import.py
+++ b/colombia/import.py
@@ -237,6 +237,26 @@ if __name__ == "__main__":
             df.to_sql("municipality_industry_year", db.engine, index=False,
                       chunksize=10000, if_exists="append")
 
+            # Livestock - country
+            ret = process_dataset(livestock_level1_country)
+            df = ret[('location_id', 'livestock_id')].reset_index()
+            df["location_level"] = "level1"
+            df.to_sql("country_livestock_year", db.engine, index=False,
+                      chunksize=10000, if_exists="append")
+
+            # Livestock - department
+            ret = process_dataset(livestock_level1_department)
+            df = ret[('location_id', 'livestock_id')].reset_index()
+            df["location_level"] = "level1"
+            df.to_sql("department_livestock_year", db.engine, index=False,
+                      chunksize=10000, if_exists="append")
+
+            # Livestock - municipality
+            ret = process_dataset(livestock_level1_municipality)
+            df = ret[('location_id', 'livestock_id')].reset_index()
+            df["location_level"] = "level1"
+            df.to_sql("municipality_livestock_year", db.engine, index=False,
+                      chunksize=10000, if_exists="append")
 
             # Occupation - year
             ret = process_dataset(occupation2digit)

--- a/colombia/import.py
+++ b/colombia/import.py
@@ -14,7 +14,9 @@ from datasets import (trade4digit_country, trade4digit_department,
                       trade4digit_rcpy_country, population,
                       gdp_nominal_department, gdp_real_department,
                       occupation2digit, occupation2digit_industry2digit,
-                      industry2digit_country)
+                      industry2digit_country, livestock_level1_country,
+                      livestock_level1_department,
+                      livestock_level1_municipality)
 
 from datasets import (product_classification,
                       industry_classification,

--- a/colombia/metadata/models.py
+++ b/colombia/metadata/models.py
@@ -1,5 +1,5 @@
 from atlas_core.sqlalchemy import BaseModel
-from atlas_core.model_mixins import IDMixin, LanguageMixin
+from atlas_core.model_mixins import IDMixin
 
 from ..core import db
 

--- a/colombia/metadata/models.py
+++ b/colombia/metadata/models.py
@@ -96,10 +96,8 @@ occupation_enum = db.Enum(*occupation_levels, name="occupation_level")
 
 
 livestock_levels = [
-    "major_group",
-    "minor_group",
-    "broad_occupation",
-    "detailed_occupation",
+    "level0",
+    "level1",
 ]
 livestock_enum = db.Enum(*livestock_levels, name="livestock_level")
 

--- a/colombia/metadata/models.py
+++ b/colombia/metadata/models.py
@@ -95,6 +95,15 @@ occupation_levels = [
 occupation_enum = db.Enum(*occupation_levels, name="occupation_level")
 
 
+livestock_levels = [
+    "major_group",
+    "minor_group",
+    "broad_occupation",
+    "detailed_occupation",
+]
+livestock_enum = db.Enum(*livestock_levels, name="livestock_level")
+
+
 class HSProduct(Metadata):
     """A product according to the HS4 (Harmonized System) classification.
     Details can be found here: http://www.wcoomd.org/en/topics/nomenclature/instrument-and-tools/hs_nomenclature_2012/hs_nomenclature_table_2012.aspx
@@ -148,3 +157,11 @@ class Country(Metadata):
     #: Possible aggregation levels
     LEVELS = country_levels
     level = db.Column(country_enum)
+
+
+class Livestock(Metadata):
+    __tablename__ = "livestock"
+
+    #: Possible aggregation levels
+    LEVELS = livestock_levels
+    level = db.Column(livestock_enum)

--- a/colombia/models.py
+++ b/colombia/models.py
@@ -7,5 +7,8 @@ from .data.models import (CountryProductYear, DepartmentProductYear,
                           MSAIndustryYear, OccupationYear,
                           OccupationIndustryYear, CountryCountryYear,
                           CountryDepartmentYear, CountryMSAYear,
-                          CountryMunicipalityYear, MSAYear, PartnerProductYear)
+                          CountryMunicipalityYear, MSAYear, PartnerProductYear,
+                          CountryLivestockYear, DepartmentLivestockYear,
+                          MunicipalityLivestockYear
+                          )
 

--- a/colombia/models.py
+++ b/colombia/models.py
@@ -1,5 +1,5 @@
 from .metadata.models import (Metadata, HSProduct, Location, Industry, Country,
-                              Occupation)
+                              Occupation, Livestock)
 from .data.models import (CountryProductYear, DepartmentProductYear,
                           DepartmentYear, ProductYear, CountryIndustryYear,
                           DepartmentIndustryYear, IndustryYear,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@ clint==0.4.1
 git+https://github.com/cid-harvard/atlas_core.git@v0.2.8#egg=atlas_core
 
 # Classifications
-git+https://github.com/cid-harvard/classifications.git@v0.0.66#egg=linnaeus
+git+https://github.com/cid-harvard/classifications.git@v0.0.71#egg=linnaeus
 
 # Reckoner - data quality / assertions
-git+https://github.com/cid-harvard/reckoner.git@850e1322226107262a9c6a9af24b9440f3b5b35b#egg=reckoner
+git+https://github.com/cid-harvard/reckoner.git@e2b55dbeac09a9f677dd83b41c6168b75872133c#egg=reckoner
 
 # Override atlas_core dependencies
 git+https://github.com/cid-harvard/flask-sqlalchemy.git@5599861ef61ac7c0f9139c525c61ab4ac0cef5b4#egg=flask-sqlalchemy


### PR DESCRIPTION
Added livestock datasets in 3 geolevels (country, department, municipality) in all stages (dataset definition, ingestion, import, db models). No MSA level right now, because that doesn't exist in Eduardo's dataset.

This time instead of a generic "level" column I went for "livestock_level" because it aligns with the new standard for the new API backend.

Didn't include a year because the data is only single year, but perhaps I should later. We have a similar issue with occupations.